### PR TITLE
CONTRIB-5471 rsslib: Fix query and post object for Post feeds

### DIFF
--- a/rsslib.php
+++ b/rsslib.php
@@ -232,7 +232,7 @@ function hsuforum_rss_feed_posts_sql($forum, $cm, $newsince=0) {
                  d.timestart,
                  d.timeend,
                  u.id AS userid,
-                 $usernamefields
+                 $usernamefields,
                  p.reveal AS postreveal,
                  p.subject AS postsubject,
                  p.message AS postmessage,
@@ -333,6 +333,7 @@ function hsuforum_rss_feed_contents($forum, $sql, $params, $context) {
             $post->id = $rec->postid;
             $post->parent = $rec->postparent;
             $post->userid = $rec->userid;
+            $post->privatereply = $rec->privatereply;
         }
 
         if ($isdiscussion && !hsuforum_user_can_see_discussion($forum, $discussion, $context)) {


### PR DESCRIPTION
If you enable rss feeds for an advanced forum (with at least 1 post in it), setting the feed to be for posts rather than discussions, then when trying to view the feed, you simply get an RSS error.

This is caused by the post query missing a comma and then by the $post object given to hsuforum_user_can_see_post missing a required property (privatereply).