### PR TITLE
Fix function call deprecated in Moodled 3.0

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -50,7 +50,7 @@ class mod_hsuforum_mod_form extends moodleform_mod {
         $mform->addRule('name', null, 'required', null, 'client');
         $mform->addRule('name', get_string('maximumchars', '', 255), 'maxlength', 255, 'client');
 
-        $this->add_intro_editor(true, get_string('forumintro', 'hsuforum'));
+        $this->standard_intro_elements(get_string('forumintro', 'hsuforum'));
 
         if (empty($config->hiderecentposts)) {
             // Display recent posts on course page?


### PR DESCRIPTION
This changes the call to add_intro_editor() to standard_intro_elements()
because add_intro_editor() has been deprecated in Moodle 3.0. This
appears to be the only change necessary to make the plugin Moodle 3.0
compliant.