### PR TITLE
Filter "unread posts" for user's group in Small Group Discussion Forums

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -6121,7 +6121,8 @@ function hsuforum_count_forum_unread_posts($cm, $course) {
 
     $groupmode = groups_get_activity_groupmode($cm, $course);
 
-    if ($groupmode != SEPARATEGROUPS) {
+    // GETSMARTER EDIT. Added  && $groupmode != VISIBLEGROUPS to the if statement below
+    if ($groupmode != SEPARATEGROUPS && $groupmode != VISIBLEGROUPS) {
         return $readcache[$course->id][$forumid];
     }
 


### PR DESCRIPTION
When groupmode is set to visible groups, the unread posts text includes all posts in all groups. It must only show the notification for their group.