### PR TITLE
hsuforum_search_posts: remove duplicate u.email

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -2315,8 +2315,7 @@ function hsuforum_search_posts($searchterms, $courseid=0, $limitfrom=0, $limitnu
                          $allnames,
                          u.email,
                          u.picture,
-                         u.imagealt,
-                         u.email
+                         u.imagealt
                     FROM $fromsql
                    WHERE $selectsql
                 ORDER BY p.modified DESC";


### PR DESCRIPTION
Remove duplicated u.email from hsuforum_search_posts()::$searchsql b/c it causes problems in Oracle.  If it's gotta remain we should alias one of the two fields e.g. 'u.email AS email2'.