### PR TITLE
Removed deprecated legacy log store functions

### DIFF
--- a/classes/event/assessable_uploaded.php
+++ b/classes/event/assessable_uploaded.php
@@ -55,35 +55,6 @@ class assessable_uploaded extends \core\event\assessable_uploaded {
     }
 
     /**
-     * Legacy event data if get_legacy_eventname() is not empty.
-     *
-     * @return \stdClass
-     */
-    protected function get_legacy_eventdata() {
-        $eventdata = new \stdClass();
-        $eventdata->modulename   = 'hsuforum';
-        $eventdata->name         = $this->other['triggeredfrom'];
-        $eventdata->cmid         = $this->contextinstanceid;
-        $eventdata->itemid       = $this->objectid;
-        $eventdata->courseid     = $this->courseid;
-        $eventdata->userid       = $this->userid;
-        $eventdata->content      = $this->other['content'];
-        if ($this->other['pathnamehashes']) {
-            $eventdata->pathnamehashes = $this->other['pathnamehashes'];
-        }
-        return $eventdata;
-    }
-
-    /**
-     * Return the legacy event name.
-     *
-     * @return string
-     */
-    public static function get_legacy_eventname() {
-        return 'assessable_content_uploaded';
-    }
-
-    /**
      * Return localised event name.
      *
      * @return string

--- a/classes/event/course_module_viewed.php
+++ b/classes/event/course_module_viewed.php
@@ -56,16 +56,6 @@ class course_module_viewed extends \core\event\course_module_viewed {
         return new \moodle_url('/mod/hsuforum/view.php', array('f' => $this->objectid));
     }
 
-    /**
-     * Return the legacy event log data.
-     *
-     * @return array|null
-     */
-    protected function get_legacy_logdata() {
-        return array($this->courseid, 'hsuforum', 'view forum', 'view.php?f=' . $this->objectid,
-            $this->objectid, $this->contextinstanceid);
-    }
-
     public static function get_objectid_mapping() {
         return array('db' => 'hsuforum', 'restore' => 'hsuforum');
     }

--- a/classes/event/course_searched.php
+++ b/classes/event/course_searched.php
@@ -83,18 +83,6 @@ class course_searched extends \core\event\base {
     }
 
     /**
-     * Return the legacy event log data.
-     *
-     * @return array|null
-     */
-    protected function get_legacy_logdata() {
-        // The legacy log table expects a relative path to /mod/hsuforum/.
-        $logurl = substr($this->get_url()->out_as_local_url(), strlen('/mod/hsuforum/'));
-
-        return array($this->courseid, 'hsuforum', 'search', $logurl, $this->other['searchterm']);
-    }
-
-    /**
      * Custom validation.
      *
      * @throws \coding_exception

--- a/classes/event/discussion_created.php
+++ b/classes/event/discussion_created.php
@@ -81,19 +81,6 @@ class discussion_created extends \core\event\base {
     }
 
     /**
-     * Return the legacy event log data.
-     *
-     * @return array|null
-     */
-    protected function get_legacy_logdata() {
-
-        // The legacy log table expects a relative path to /mod/hsuforum/.
-        $logurl = substr($this->get_url()->out_as_local_url(), strlen('/mod/hsuforum/'));
-
-        return array($this->courseid, 'hsuforum', 'add discussion', $logurl, $this->objectid, $this->contextinstanceid);
-    }
-
-    /**
      * Custom validation.
      *
      * @throws \coding_exception

--- a/classes/event/discussion_deleted.php
+++ b/classes/event/discussion_deleted.php
@@ -82,16 +82,6 @@ class discussion_deleted extends \core\event\base {
     }
 
     /**
-     * Return the legacy event log data.
-     *
-     * @return array|null
-     */
-    protected function get_legacy_logdata() {
-        return array($this->courseid, 'hsuforum', 'delete discussion', 'view.php?id=' . $this->contextinstanceid,
-            $this->other['forumid'], $this->contextinstanceid);
-    }
-
-    /**
      * Custom validation.
      *
      * @throws \coding_exception

--- a/classes/event/discussion_moved.php
+++ b/classes/event/discussion_moved.php
@@ -82,16 +82,6 @@ class discussion_moved extends \core\event\base {
     }
 
     /**
-     * Return the legacy event log data.
-     *
-     * @return array|null
-     */
-    protected function get_legacy_logdata() {
-        return array($this->courseid, 'hsuforum', 'move discussion', 'discuss.php?d=' . $this->objectid,
-            $this->objectid, $this->contextinstanceid);
-    }
-
-    /**
      * Custom validation.
      *
      * @throws \coding_exception

--- a/classes/event/discussion_pinned.php
+++ b/classes/event/discussion_pinned.php
@@ -71,17 +71,6 @@ class discussion_pinned extends \core\event\base {
     }
 
     /**
-     * Return the legacy event log data.
-     *
-     * @return array|null
-     */
-    protected function get_legacy_logdata() {
-        // The legacy log table expects a relative path to /mod/hsuforum/.
-        $logurl = substr($this->get_url()->out_as_local_url(), strlen('/mod/hsuforum/'));
-        return array($this->courseid, 'hsuforum', 'pin discussion', $logurl, $this->objectid, $this->contextinstanceid);
-    }
-
-    /**
      * Custom validation.
      *
      * @throws \coding_exception

--- a/classes/event/discussion_unpinned.php
+++ b/classes/event/discussion_unpinned.php
@@ -71,17 +71,6 @@ class discussion_unpinned extends \core\event\base {
     }
 
     /**
-     * Return the legacy event log data.
-     *
-     * @return array|null
-     */
-    protected function get_legacy_logdata() {
-        // The legacy log table expects a relative path to /mod/hsuforum/.
-        $logurl = substr($this->get_url()->out_as_local_url(), strlen('/mod/hsuforum/'));
-        return array($this->courseid, 'hsuforum', 'unpin discussion', $logurl, $this->objectid, $this->contextinstanceid);
-    }
-
-    /**
      * Custom validation.
      *
      * @throws \coding_exception

--- a/classes/event/discussion_viewed.php
+++ b/classes/event/discussion_viewed.php
@@ -76,16 +76,6 @@ class discussion_viewed extends \core\event\base {
     }
 
     /**
-     * Return the legacy event log data.
-     *
-     * @return array|null
-     */
-    protected function get_legacy_logdata() {
-        return array($this->courseid, 'hsuforum', 'view discussion', 'discuss.php?d=' . $this->objectid,
-            $this->objectid, $this->contextinstanceid);
-    }
-
-    /**
      * Custom validation.
      *
      * @throws \coding_exception

--- a/classes/event/post_created.php
+++ b/classes/event/post_created.php
@@ -92,18 +92,6 @@ class post_created extends \core\event\base {
     }
 
     /**
-     * Return the legacy event log data.
-     *
-     * @return array|null
-     */
-    protected function get_legacy_logdata() {
-        // The legacy log table expects a relative path to /mod/hsuforum/.
-        $logurl = substr($this->get_url()->out_as_local_url(), strlen('/mod/hsuforum/'));
-
-        return array($this->courseid, 'hsuforum', 'add post', $logurl, $this->other['forumid'], $this->contextinstanceid);
-    }
-
-    /**
      * Custom validation.
      *
      * @throws \coding_exception

--- a/classes/event/post_deleted.php
+++ b/classes/event/post_deleted.php
@@ -91,18 +91,6 @@ class post_deleted extends \core\event\base {
     }
 
     /**
-     * Return the legacy event log data.
-     *
-     * @return array|null
-     */
-    protected function get_legacy_logdata() {
-        // The legacy log table expects a relative path to /mod/hsuforum/.
-        $logurl = substr($this->get_url()->out_as_local_url(), strlen('/mod/hsuforum/'));
-
-        return array($this->courseid, 'hsuforum', 'delete post', $logurl, $this->objectid, $this->contextinstanceid);
-    }
-
-    /**
      * Custom validation.
      *
      * @throws \coding_exception

--- a/classes/event/post_updated.php
+++ b/classes/event/post_updated.php
@@ -92,18 +92,6 @@ class post_updated extends \core\event\base {
     }
 
     /**
-     * Return the legacy event log data.
-     *
-     * @return array|null
-     */
-    protected function get_legacy_logdata() {
-        // The legacy log table expects a relative path to /mod/hsuforum/.
-        $logurl = substr($this->get_url()->out_as_local_url(), strlen('/mod/hsuforum/'));
-
-        return array($this->courseid, 'hsuforum', 'update post', $logurl, $this->objectid, $this->contextinstanceid);
-    }
-
-    /**
      * Custom validation.
      *
      * @throws \coding_exception

--- a/classes/event/readtracking_disabled.php
+++ b/classes/event/readtracking_disabled.php
@@ -80,16 +80,6 @@ class readtracking_disabled extends \core\event\base {
     }
 
     /**
-     * Return the legacy event log data.
-     *
-     * @return array|null
-     */
-    protected function get_legacy_logdata() {
-        return array($this->courseid, 'hsuforum', 'stop tracking', 'view.php?f=' . $this->other['forumid'],
-            $this->other['forumid'], $this->contextinstanceid);
-    }
-
-    /**
      * Custom validation.
      *
      * @throws \coding_exception

--- a/classes/event/readtracking_enabled.php
+++ b/classes/event/readtracking_enabled.php
@@ -80,16 +80,6 @@ class readtracking_enabled extends \core\event\base {
     }
 
     /**
-     * Return the legacy event log data.
-     *
-     * @return array|null
-     */
-    protected function get_legacy_logdata() {
-        return array($this->courseid, 'hsuforum', 'start tracking', 'view.php?f=' . $this->other['forumid'],
-            $this->other['forumid'], $this->contextinstanceid);
-    }
-
-    /**
      * Custom validation.
      *
      * @throws \coding_exception

--- a/classes/event/subscribers_viewed.php
+++ b/classes/event/subscribers_viewed.php
@@ -81,16 +81,6 @@ class subscribers_viewed extends \core\event\base {
     }
 
     /**
-     * Return the legacy event log data.
-     *
-     * @return array|null
-     */
-    protected function get_legacy_logdata() {
-        return array($this->courseid, 'hsuforum', 'view subscribers', 'subscribers.php?id=' . $this->other['forumid'],
-            $this->other['forumid'], $this->contextinstanceid);
-    }
-
-    /**
      * Custom validation.
      *
      * @throws \coding_exception

--- a/classes/event/subscription_created.php
+++ b/classes/event/subscription_created.php
@@ -81,16 +81,6 @@ class subscription_created extends \core\event\base {
     }
 
     /**
-     * Return the legacy event log data.
-     *
-     * @return array|null
-     */
-    protected function get_legacy_logdata() {
-        return array($this->courseid, 'hsuforum', 'subscribe', 'view.php?f=' . $this->other['forumid'],
-            $this->other['forumid'], $this->contextinstanceid);
-    }
-
-    /**
      * Custom validation.
      *
      * @throws \coding_exception

--- a/classes/event/subscription_deleted.php
+++ b/classes/event/subscription_deleted.php
@@ -81,16 +81,6 @@ class subscription_deleted extends \core\event\base {
     }
 
     /**
-     * Return the legacy event log data.
-     *
-     * @return array|null
-     */
-    protected function get_legacy_logdata() {
-        return array($this->courseid, 'hsuforum', 'unsubscribe', 'view.php?f=' . $this->other['forumid'],
-            $this->other['forumid'], $this->contextinstanceid);
-    }
-
-    /**
      * Custom validation.
      *
      * @throws \coding_exception

--- a/classes/event/user_report_viewed.php
+++ b/classes/event/user_report_viewed.php
@@ -89,18 +89,6 @@ class user_report_viewed extends \core\event\base {
     }
 
     /**
-     * Return the legacy event log data.
-     *
-     * @return array|null
-     */
-    protected function get_legacy_logdata() {
-        // The legacy log table expects a relative path to /mod/hsuforum/.
-        $logurl = substr($this->get_url()->out_as_local_url(), strlen('/mod/hsuforum/'));
-
-        return array($this->courseid, 'hsuforum', 'user report', $logurl, $this->relateduserid);
-    }
-
-    /**
      * Custom validation.
      *
      * @throws \coding_exception


### PR DESCRIPTION
Since Moodle 4.2 the legacy log store is deprecated (see: MDL-52805) and the related functions need to be removed from the code as done in this commit.
This will resolve #53.

