### PR TITLE
fix debug notice when creating a post

### DIFF
--- a/classes/service/discussion_service.php
+++ b/classes/service/discussion_service.php
@@ -138,6 +138,7 @@ class discussion_service {
             'mailnow'       => 0,
             'reveal'        => 0,
             'pinned'        => 0,
+            'timelocked'    => 0,
         );
         foreach ($options as $name => $value) {
             if (property_exists($discussion, $name)) {


### PR DESCRIPTION
Got this debug notice when creating a discussion:

```
Fields list in snapshot record does not match fields list in 'hsuforum_discussions'. Record is missing fields: timelocked
line 863 of /lib/classes/event/base.php: call to debugging()
line 248 of /mod/hsuforum/classes/service/discussion_service.php: call to core\event\base->add_record_snapshot()
line 104 of /mod/hsuforum/classes/service/discussion_service.php: call to mod_hsuforum\service\discussion_service->trigger_discussion_created()
line 180 of /mod/hsuforum/classes/controller/edit_controller.php: call to mod_hsuforum\service\discussion_service->handle_add_discussion()
line ? of unknownfile: call to mod_hsuforum\controller\edit_controller->add_discussion_action()
line 124 of /mod/hsuforum/classes/controller/kernel.php: call to call_user_func()
line 89 of /mod/hsuforum/classes/controller/kernel.php: call to mod_hsuforum\controller\kernel->generate_response()
line 83 of /mod/hsuforum/route.php: call to mod_hsuforum\controller\kernel->handle()
```